### PR TITLE
Add KTORM-style arithmetic operators

### DIFF
--- a/src/main/kotlin/org/finos/legendql/kotlin/dsl/Column.kt
+++ b/src/main/kotlin/org/finos/legendql/kotlin/dsl/Column.kt
@@ -145,3 +145,75 @@ fun Column<*>.isNotNull(): BinaryExpression {
         IsNotNullBinaryOperator()
     )
 }
+
+/**
+ * Addition operator
+ */
+operator fun <T : Number> Column<T>.plus(value: Number): BinaryExpression {
+    val valueExpr = when (value) {
+        is Int -> LiteralExpression(IntegerLiteral(value))
+        is Double -> LiteralExpression(DoubleLiteral(value))
+        is Long -> LiteralExpression(LongLiteral(value))
+        else -> throw IllegalArgumentException("Unsupported type: ${value.javaClass}")
+    }
+    
+    return BinaryExpression(
+        OperandExpression(this.asExpression()),
+        OperandExpression(valueExpr),
+        AdditionBinaryOperator()
+    )
+}
+
+/**
+ * Subtraction operator
+ */
+operator fun <T : Number> Column<T>.minus(value: Number): BinaryExpression {
+    val valueExpr = when (value) {
+        is Int -> LiteralExpression(IntegerLiteral(value))
+        is Double -> LiteralExpression(DoubleLiteral(value))
+        is Long -> LiteralExpression(LongLiteral(value))
+        else -> throw IllegalArgumentException("Unsupported type: ${value.javaClass}")
+    }
+    
+    return BinaryExpression(
+        OperandExpression(this.asExpression()),
+        OperandExpression(valueExpr),
+        SubtractionBinaryOperator()
+    )
+}
+
+/**
+ * Multiplication operator
+ */
+operator fun <T : Number> Column<T>.times(value: Number): BinaryExpression {
+    val valueExpr = when (value) {
+        is Int -> LiteralExpression(IntegerLiteral(value))
+        is Double -> LiteralExpression(DoubleLiteral(value))
+        is Long -> LiteralExpression(LongLiteral(value))
+        else -> throw IllegalArgumentException("Unsupported type: ${value.javaClass}")
+    }
+    
+    return BinaryExpression(
+        OperandExpression(this.asExpression()),
+        OperandExpression(valueExpr),
+        MultiplicationBinaryOperator()
+    )
+}
+
+/**
+ * Division operator
+ */
+operator fun <T : Number> Column<T>.div(value: Number): BinaryExpression {
+    val valueExpr = when (value) {
+        is Int -> LiteralExpression(IntegerLiteral(value))
+        is Double -> LiteralExpression(DoubleLiteral(value))
+        is Long -> LiteralExpression(LongLiteral(value))
+        else -> throw IllegalArgumentException("Unsupported type: ${value.javaClass}")
+    }
+    
+    return BinaryExpression(
+        OperandExpression(this.asExpression()),
+        OperandExpression(valueExpr),
+        DivisionBinaryOperator()
+    )
+}

--- a/src/main/kotlin/org/finos/legendql/kotlin/examples/Examples.kt
+++ b/src/main/kotlin/org/finos/legendql/kotlin/examples/Examples.kt
@@ -119,13 +119,13 @@ object Examples {
     fun extending() {
         val database = createDatabase()
         
-        // Extend with computed columns
+        // Extend with computed columns using KTORM-style operators
         val query = database
             .from(Employees)
             .select(Employees.name, Employees.salary)
             .extend(
                 listOf(
-                    (Employees.salary.asExpression() + LiteralExpression(IntegerLiteral(1000))).aliased("bonus")
+                    (Employees.salary + 1000).aliased("bonus")
                 )
             )
         
@@ -239,7 +239,7 @@ object Examples {
             .where { Employees.age gt 30 }
             .extend(
                 listOf(
-                    (Employees.salary.asExpression() + LiteralExpression(IntegerLiteral(1000))).aliased("bonus")
+                    (Employees.salary + 1000).aliased("bonus")
                 )
             )
             .orderBy(Employees.salary.desc())
@@ -251,6 +251,41 @@ object Examples {
         println("Complex Query:")
         println(result.executableToString())
         println()
+    }
+    
+    /**
+     * Example of arithmetic operators in KTORM-style syntax
+     */
+    fun arithmeticOperators() {
+        val database = createDatabase()
+        
+        // Query using arithmetic operators
+        val query = database
+            .from(Employees)
+            .select(
+                Employees.name,
+                Employees.salary,
+                (Employees.salary + 1000).aliased("salary_plus"),
+                (Employees.salary - 500).aliased("salary_minus"),
+                (Employees.salary * 2).aliased("salary_times"),
+                (Employees.salary / 2).aliased("salary_divided")
+            )
+        
+        val runtime = NonExecutablePureRuntime()
+        val result = query.bind(runtime)
+        
+        println("Arithmetic Operators Query:")
+        println(result.executableToString())
+        println()
+        
+        // In a real implementation, this would print actual data
+        query.forEach { row ->
+            println("${row[Employees.name]}: ${row[Employees.salary]}")
+            println("  + 1000 = ${row["salary_plus"]}")
+            println("  - 500 = ${row["salary_minus"]}")
+            println("  * 2 = ${row["salary_times"]}")
+            println("  / 2 = ${row["salary_divided"]}")
+        }
     }
     
     /**
@@ -271,6 +306,7 @@ object Examples {
         joining()
         limitingAndOffsetting()
         complexQuery()
+        arithmeticOperators()
         
         println("All examples completed successfully")
     }


### PR DESCRIPTION
# Add KTORM-style arithmetic operators (+, -, *, /)

This PR implements arithmetic operators (+, -, *, /) in the DSL to match KTORM syntax as requested. The implementation allows for simplified expressions like:

```kotlin
(Employees.salary + 1000).aliased("bonus")
```

Instead of the more verbose:

```kotlin
(Employees.salary.asExpression() + LiteralExpression(IntegerLiteral(1000))).aliased("bonus")
```

## Changes

1. Added operator functions in Column.kt:
   - plus() for column + number
   - minus() for column - number
   - times() for column * number
   - div() for column / number

2. Updated Examples.kt to use the new operators
3. Added a dedicated example function for arithmetic operators

Link to Devin run: https://app.devin.ai/sessions/a0205b5ed6904696a3d6be6cbccfb9b0
Requested by: Neema.Raphael@gs.com