### PR TITLE
Improve having() and extend() syntax with cleaner avg() function and operator overloading

### DIFF
--- a/src/main/kotlin/org/finos/legendql/kotlin/dsl/Extensions.kt
+++ b/src/main/kotlin/org/finos/legendql/kotlin/dsl/Extensions.kt
@@ -113,3 +113,20 @@ infix fun FunctionExpression.gt(value: Double): BinaryExpression {
         GreaterThanBinaryOperator()
     )
 }
+
+/**
+ * Greater than operator (>) for function expressions - Kotlin operator overloading
+ */
+operator fun FunctionExpression.compareTo(value: Double): Int {
+    val expr = BinaryExpression(
+        OperandExpression(this),
+        OperandExpression(LiteralExpression(DoubleLiteral(value))),
+        GreaterThanBinaryOperator()
+    )
+    
+    // Store the expression in the context
+    OperatorContext.setLastExpression(expr)
+    
+    // Return 0 to satisfy the compiler, but this value is never actually used
+    return 0
+}

--- a/src/main/kotlin/org/finos/legendql/kotlin/examples/Examples.kt
+++ b/src/main/kotlin/org/finos/legendql/kotlin/examples/Examples.kt
@@ -126,11 +126,9 @@ object Examples {
         val query = database
             .from(Employees)
             .select(Employees.name, Employees.salary)
-            .extend(
-                listOf(
-                    (Employees.salary + 1000).aliased("bonus")
-                )
-            )
+            .extend { 
+                (Employees.salary + 1000).aliased("bonus")
+            }
         
         val runtime = NonExecutablePureRuntime()
         val result = query.bind(runtime)
@@ -174,9 +172,9 @@ object Examples {
         val query = database
             .from(Employees)
             .select(Employees.departmentId)
-            .extend(listOf(Employees.salary.avg().aliased("avg_salary")))
+            .extend { avg(Employees.salary).aliased("avg_salary") }
             .groupBy(Employees.departmentId)
-            .having { FunctionExpression(AverageFunction(), listOf(Employees.salary.asExpression())) gt 1000.0 }
+            .having { avg(Employees.salary) > 1000.0 }
         
         val runtime = NonExecutablePureRuntime()
         val result = query.bind(runtime)
@@ -241,11 +239,9 @@ object Examples {
             .from(Employees)
             .select(Employees.name, Employees.salary)
             .where { Employees.age gt 30 }
-            .extend(
-                listOf(
-                    (Employees.salary + 1000).aliased("bonus")
-                )
-            )
+            .extend { 
+                (Employees.salary + 1000).aliased("bonus")
+            }
             .orderBy(Employees.salary.desc())
             .limit(10)
         
@@ -270,14 +266,14 @@ object Examples {
                 Employees.name,
                 Employees.salary
             )
-            .extend(
+            .extend { 
                 listOf(
                     (Employees.salary + 1000).aliased("salary_plus"),
                     (Employees.salary - 500).aliased("salary_minus"),
                     (Employees.salary * 2).aliased("salary_times"),
                     (Employees.salary / 2).aliased("salary_divided")
                 )
-            )
+            }
         
         val runtime = NonExecutablePureRuntime()
         val result = query.bind(runtime)
@@ -287,7 +283,7 @@ object Examples {
         println()
         
         // In a real implementation, this would print actual data
-        query.forEach { row ->
+        query.forEach { row: Row ->
             println("${row[Employees.name]}: ${row[Employees.salary]}")
             println("  + 1000 = ${row.get<Double>("salary_plus")}")
             println("  - 500 = ${row.get<Double>("salary_minus")}")

--- a/src/test/kotlin/org/finos/legendql/kotlin/dsl/KtormStyleDslTest.kt
+++ b/src/test/kotlin/org/finos/legendql/kotlin/dsl/KtormStyleDslTest.kt
@@ -72,7 +72,7 @@ class KtormStyleDslTest {
         val query = database
             .from(Employees)
             .select(Employees.departmentId)
-            .extend(listOf(avg(Employees.salary).aliased("avg_salary")))
+            .extend { avg(Employees.salary).aliased("avg_salary") }
             .groupBy(Employees.departmentId)
             
         val runtime = NonExecutablePureRuntime()


### PR DESCRIPTION
# Improve DSL Syntax for having() and extend() Methods

This PR improves the DSL syntax for the `having()` and `extend()` methods to make them more KTORM-like and intuitive to use.

## Changes

### having() Method
- Updated the syntax from verbose `FunctionExpression(AverageFunction(), listOf(Employees.salary.asExpression())) gt 1000.0` to more readable `avg(Employees.salary) > 1000.0`
- Added operator overloading for FunctionExpression to support the `>` operator
- Modified the having() method to retrieve expressions from OperatorContext

### extend() Method
- Updated the syntax from `.extend(listOf(...))` to `.extend { ... }`
- Implemented a more flexible extend() method that handles both single expressions and lists
- Updated all examples and tests to use the new syntax

## Before
```kotlin
.having { FunctionExpression(AverageFunction(), listOf(Employees.salary.asExpression())) gt 1000.0 }
.extend(listOf(Employees.salary.avg().aliased("avg_salary")))
```

## After
```kotlin
.having { avg(Employees.salary) > 1000.0 }
.extend { avg(Employees.salary).aliased("avg_salary") }
```

## Testing
- All tests pass
- Project builds successfully

Link to Devin run: https://app.devin.ai/sessions/a0205b5ed6904696a3d6be6cbccfb9b0
Requested by: Neema Raphael