### PR TITLE
Fix operator overloading implementation to use infix functions

### DIFF
--- a/src/main/kotlin/org/finos/legendql/kotlin/dsl/Column.kt
+++ b/src/main/kotlin/org/finos/legendql/kotlin/dsl/Column.kt
@@ -164,22 +164,32 @@ infix fun <T> Column<T>.eq(value: T): BinaryExpression {
         else -> throw IllegalArgumentException("Unsupported type: ${value?.javaClass}")
     }
     
-    return BinaryExpression(
+    val expr = BinaryExpression(
         OperandExpression(this.asExpression()),
         OperandExpression(valueExpr),
         EqualsBinaryOperator()
     )
+    
+    // Store the expression in the context
+    OperatorContext.setLastExpression(expr)
+    
+    return expr
 }
 
 /**
  * Equals operator for comparing two columns
  */
 infix fun <T> Column<T>.eq(other: Column<T>): BinaryExpression {
-    return BinaryExpression(
+    val expr = BinaryExpression(
         OperandExpression(this.asExpression()),
         OperandExpression(other.asExpression()),
         EqualsBinaryOperator()
     )
+    
+    // Store the expression in the context
+    OperatorContext.setLastExpression(expr)
+    
+    return expr
 }
 
 /**
@@ -189,15 +199,21 @@ infix fun <T : Comparable<T>> Column<T>.lt(value: T): BinaryExpression {
     val valueExpr = when (value) {
         is Int -> LiteralExpression(IntegerLiteral(value))
         is String -> LiteralExpression(StringLiteral(value))
+        is Double -> LiteralExpression(DoubleLiteral(value))
         is Column<*> -> value.asExpression()
         else -> throw IllegalArgumentException("Unsupported type: ${value.javaClass}")
     }
     
-    return BinaryExpression(
+    val expr = BinaryExpression(
         OperandExpression(this.asExpression()),
         OperandExpression(valueExpr),
         LessThanBinaryOperator()
     )
+    
+    // Store the expression in the context
+    OperatorContext.setLastExpression(expr)
+    
+    return expr
 }
 
 /**
@@ -212,11 +228,16 @@ infix fun <T : Comparable<T>> Column<T>.gt(value: T): BinaryExpression {
         else -> throw IllegalArgumentException("Unsupported type: ${value.javaClass}")
     }
     
-    return BinaryExpression(
+    val expr = BinaryExpression(
         OperandExpression(this.asExpression()),
         OperandExpression(valueExpr),
         GreaterThanBinaryOperator()
     )
+    
+    // Store the expression in the context
+    OperatorContext.setLastExpression(expr)
+    
+    return expr
 }
 
 /**
@@ -345,55 +366,80 @@ fun <T : Comparable<T>> captureGreaterThanOrEqual(left: Column<T>, right: T): Bi
  * Like operator for string pattern matching
  */
 infix fun Column<String>.like(pattern: String): BinaryExpression {
-    return BinaryExpression(
+    val expr = BinaryExpression(
         OperandExpression(this.asExpression()),
         OperandExpression(LiteralExpression(StringLiteral(pattern))),
         LikeBinaryOperator()
     )
+    
+    // Store the expression in the context
+    OperatorContext.setLastExpression(expr)
+    
+    return expr
 }
 
 /**
  * Logical AND operator
  */
 infix fun BinaryExpression.and(expr: BinaryExpression): BinaryExpression {
-    return BinaryExpression(
+    val result = BinaryExpression(
         OperandExpression(this),
         OperandExpression(expr),
         AndBinaryOperator()
     )
+    
+    // Store the expression in the context
+    OperatorContext.setLastExpression(result)
+    
+    return result
 }
 
 /**
  * Logical OR operator
  */
 infix fun BinaryExpression.or(expr: BinaryExpression): BinaryExpression {
-    return BinaryExpression(
+    val result = BinaryExpression(
         OperandExpression(this),
         OperandExpression(expr),
         OrBinaryOperator()
     )
+    
+    // Store the expression in the context
+    OperatorContext.setLastExpression(result)
+    
+    return result
 }
 
 /**
  * Check if value is null
  */
 fun Column<*>.isNull(): BinaryExpression {
-    return BinaryExpression(
+    val expr = BinaryExpression(
         OperandExpression(this.asExpression()),
         OperandExpression(NullExpression()),
         IsNullBinaryOperator()
     )
+    
+    // Store the expression in the context
+    OperatorContext.setLastExpression(expr)
+    
+    return expr
 }
 
 /**
  * Check if value is not null
  */
 fun Column<*>.isNotNull(): BinaryExpression {
-    return BinaryExpression(
+    val expr = BinaryExpression(
         OperandExpression(this.asExpression()),
         OperandExpression(NullExpression()),
         IsNotNullBinaryOperator()
     )
+    
+    // Store the expression in the context
+    OperatorContext.setLastExpression(expr)
+    
+    return expr
 }
 
 /**

--- a/src/main/kotlin/org/finos/legendql/kotlin/dsl/Database.kt
+++ b/src/main/kotlin/org/finos/legendql/kotlin/dsl/Database.kt
@@ -101,19 +101,21 @@ class QueryBuilder<E>(
     /**
      * Filter rows using a condition
      */
-    fun where(condition: () -> BinaryExpression): QueryBuilder<E> {
+    fun where(condition: () -> Any): QueryBuilder<E> {
         // Clear any previous context
         OperatorContext.clearContext()
         
-        // Try to get the expression from the condition lambda
-        val expr = try {
+        // Execute the condition to trigger operator overloading
+        try {
             condition()
         } catch (e: UnsupportedOperationException) {
-            // If an exception was thrown, check if we have a captured expression
-            OperatorContext.getLastExpression() ?: throw RuntimeException(
-                "Failed to capture expression in where clause. Make sure you're using the DSL correctly.", e
-            )
+            // Ignore exceptions, we're just trying to trigger operator overloading
         }
+        
+        // Get the expression from the context
+        val expr = OperatorContext.getLastExpression() ?: throw RuntimeException(
+            "Failed to capture expression in where clause. Make sure you're using the DSL correctly."
+        )
         
         query.filter(expr)
         return this
@@ -200,7 +202,7 @@ class QueryBuilder<E>(
      */
     fun <T> innerJoin(
         otherTable: Table<T>, 
-        on: () -> BinaryExpression
+        on: () -> Any
     ): JoinQueryBuilder<E, T> {
         val otherTableModel = org.finos.legendql.kotlin.model.Table(
             otherTable.tableName, 
@@ -210,15 +212,17 @@ class QueryBuilder<E>(
         // Clear any previous context
         OperatorContext.clearContext()
         
-        // Try to get the expression from the on lambda
-        val expr = try {
+        // Execute the condition to trigger operator overloading
+        try {
             on()
         } catch (e: UnsupportedOperationException) {
-            // If an exception was thrown, check if we have a captured expression
-            OperatorContext.getLastExpression() ?: throw RuntimeException(
-                "Failed to capture expression in join condition. Make sure you're using the DSL correctly.", e
-            )
+            // Ignore exceptions, we're just trying to trigger operator overloading
         }
+        
+        // Get the expression from the context
+        val expr = OperatorContext.getLastExpression() ?: throw RuntimeException(
+            "Failed to capture expression in join condition. Make sure you're using the DSL correctly."
+        )
         
         query.join(
             database.name,
@@ -235,7 +239,7 @@ class QueryBuilder<E>(
      */
     fun <T> leftJoin(
         otherTable: Table<T>, 
-        on: () -> BinaryExpression
+        on: () -> Any
     ): JoinQueryBuilder<E, T> {
         val otherTableModel = org.finos.legendql.kotlin.model.Table(
             otherTable.tableName, 
@@ -245,15 +249,17 @@ class QueryBuilder<E>(
         // Clear any previous context
         OperatorContext.clearContext()
         
-        // Try to get the expression from the on lambda
-        val expr = try {
+        // Execute the condition to trigger operator overloading
+        try {
             on()
         } catch (e: UnsupportedOperationException) {
-            // If an exception was thrown, check if we have a captured expression
-            OperatorContext.getLastExpression() ?: throw RuntimeException(
-                "Failed to capture expression in join condition. Make sure you're using the DSL correctly.", e
-            )
+            // Ignore exceptions, we're just trying to trigger operator overloading
         }
+        
+        // Get the expression from the context
+        val expr = OperatorContext.getLastExpression() ?: throw RuntimeException(
+            "Failed to capture expression in join condition. Make sure you're using the DSL correctly."
+        )
         
         query.join(
             database.name,

--- a/src/main/kotlin/org/finos/legendql/kotlin/examples/Examples.kt
+++ b/src/main/kotlin/org/finos/legendql/kotlin/examples/Examples.kt
@@ -101,7 +101,7 @@ object Examples {
         // Filter by department ID and name pattern using operator overloading (==, &&)
         val query = database
             .from(Employees)
-            .where { Employees.departmentId eq 1 and (Employees.name like "%vince%") }
+            .where { (Employees.departmentId eq 1) and (Employees.name like "%vince%") }
         
         val runtime = NonExecutablePureRuntime()
         val result = query.bind(runtime)
@@ -174,7 +174,7 @@ object Examples {
             .select(Employees.departmentId)
             .extend { avg(Employees.salary).aliased("avg_salary") }
             .groupBy(Employees.departmentId)
-            .having { avg(Employees.salary) > 1000.0 }
+            .having { avg(Employees.salary) gt 1000.0 }
         
         val runtime = NonExecutablePureRuntime()
         val result = query.bind(runtime)


### PR DESCRIPTION
# Fix operator overloading implementation to use infix functions

This PR fixes the operator overloading implementation to properly use infix functions.

## Changes
- Updated all infix functions (eq, gt, lt, like, and, or) to properly store expressions in OperatorContext
- Fixed isNull() and isNotNull() functions to work correctly with the DSL
- Updated Examples.kt to use infix functions consistently throughout
- Fixed Database.kt to properly capture expressions from lambdas

## Before
```kotlin
.where { Employees.age > 30 }
.where { (Employees.departmentId == 1) && (Employees.name like "%vince%") }
```

## After
```kotlin
.where { Employees.age gt 30 }
.where { (Employees.departmentId eq 1) and (Employees.name like "%vince%") }
```

All tests now pass successfully.

Link to Devin run: https://app.devin.ai/sessions/a0205b5ed6904696a3d6be6cbccfb9b0
Requested by: neema.raphael@gs.com